### PR TITLE
fix(plugin): remove rasterio to fix ModuleNotFoundError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,5 +142,5 @@ temp.py
 temp_data
 
 # QGIS plugin build artifacts
-qgis_plugin/dsm2dtm/ext_libs/
+# qgis_plugin/dsm2dtm/ext_libs/
 qgis_plugin/dist/

--- a/qgis_plugin/dsm2dtm/ext_libs/dsm2dtm_core/__init__.py
+++ b/qgis_plugin/dsm2dtm/ext_libs/dsm2dtm_core/__init__.py
@@ -1,0 +1,5 @@
+"""Generate DTM (Digital Terrain Model) from DSM (Digital Surface Model)"""
+
+__all__ = []
+
+__version__ = "plugin_vendored"

--- a/qgis_plugin/dsm2dtm/ext_libs/dsm2dtm_core/algorithm.py
+++ b/qgis_plugin/dsm2dtm/ext_libs/dsm2dtm_core/algorithm.py
@@ -1,0 +1,321 @@
+"""
+Core algorithms for DSM to DTM conversion.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional, Tuple
+
+import numpy as np
+from scipy.ndimage import gaussian_filter, grey_opening, zoom, distance_transform_edt
+
+# Backward compatibility for numpy < 1.21 (QGIS uses 1.20)
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+else:
+    NDArray = np.ndarray
+
+from dsm2dtm_core.constants import (
+    DEFAULT_NODATA,
+    FINAL_SMOOTH_SIGMA_METERS,
+    GAP_FILL_MAX_SEARCH_DISTANCE_METERS,
+    GAP_FILL_SMOOTHING_ITERATIONS,
+    MIN_PROCESSING_RESOLUTION_METERS,
+    PMF_INITIAL_THRESHOLD,
+    PMF_INITIAL_WINDOW_METERS,
+    PMF_MAX_THRESHOLD,
+    PMF_MAX_WINDOW_METERS,
+    PMF_SLOPE,
+    REFINEMENT_ELEVATION_THRESHOLD,
+    REFINEMENT_SMOOTH_SIGMA_METERS,
+)
+
+
+@dataclass
+class AdaptiveParameters:
+    """Parameters adapted to the specific DSM resolution."""
+
+    pmf_initial_window: int
+    pmf_max_window: int
+    pmf_slope: float
+    refinement_smooth_sigma: float
+    final_smooth_sigma: float
+    gap_fill_search_dist: float
+
+
+def calculate_terrain_slope(dsm: NDArray[np.floating], resolution: float, nodata: float) -> float:
+    """
+    Calculate the median terrain slope (rise/run) of the DSM.
+    """
+    target_res = 1.0
+    current_res = max(resolution, 0.001)
+
+    if current_res < (target_res * 0.5):
+        scale_factor = current_res / target_res
+        dsm_for_slope = zoom(dsm, scale_factor, order=1)
+        res_for_slope = target_res
+    else:
+        dsm_for_slope = dsm
+        res_for_slope = current_res
+
+    valid_mask = dsm_for_slope != nodata
+    if not np.any(valid_mask):
+        return PMF_SLOPE
+
+    if dsm_for_slope.shape[0] < 2 or dsm_for_slope.shape[1] < 2:
+        return PMF_SLOPE
+
+    dsm_nan = dsm_for_slope.copy()
+    dsm_nan[~valid_mask] = np.nan
+
+    dy, dx = np.gradient(dsm_nan)
+    slope_per_pixel = np.sqrt(dy**2 + dx**2)
+    slope_dimensionless = slope_per_pixel / res_for_slope
+
+    valid_slopes = slope_dimensionless[valid_mask]
+
+    if len(valid_slopes) == 0 or np.all(np.isnan(valid_slopes)):
+        return PMF_SLOPE
+
+    median_slope = np.nanmedian(valid_slopes)
+    median_slope = max(0.01, min(median_slope, 1.0))
+    return float(median_slope)
+
+
+def get_adaptive_parameters(
+    resolution: float, max_image_dimension: int = 10000, base_slope: float = PMF_SLOPE
+) -> AdaptiveParameters:
+    """Calculate algorithm parameters based on input resolution in meters."""
+    res_meters = max(resolution, 0.001)
+    init_window = int(PMF_INITIAL_WINDOW_METERS / res_meters)
+    if init_window % 2 == 0:
+        init_window += 1
+    init_window = max(3, init_window)
+    max_window_target = int(PMF_MAX_WINDOW_METERS / res_meters)
+
+    limit = max_image_dimension
+    if limit % 2 == 0:
+        limit -= 1
+
+    max_window = min(max_window_target, limit)
+    if max_window % 2 == 0:
+        max_window -= 1
+    max_window = max(init_window, max_window)
+    pmf_slope = base_slope * res_meters
+    refine_sigma = REFINEMENT_SMOOTH_SIGMA_METERS / res_meters
+    final_sigma = FINAL_SMOOTH_SIGMA_METERS / res_meters
+    gap_dist = GAP_FILL_MAX_SEARCH_DISTANCE_METERS / res_meters
+
+    return AdaptiveParameters(
+        pmf_initial_window=init_window,
+        pmf_max_window=max_window,
+        pmf_slope=pmf_slope,
+        refinement_smooth_sigma=refine_sigma,
+        final_smooth_sigma=final_sigma,
+        gap_fill_search_dist=gap_dist,
+    )
+
+
+def progressive_morphological_filter(
+    surface: NDArray[np.floating],
+    nodata: float,
+    initial_window: int,
+    max_window: int,
+    slope: float,
+    initial_threshold: float = PMF_INITIAL_THRESHOLD,
+    max_threshold: float = PMF_MAX_THRESHOLD,
+) -> NDArray[np.floating]:
+    """Apply the Progressive Morphological Filter (PMF)."""
+    valid_mask = surface != nodata
+    if not np.any(valid_mask):
+        return surface.copy()
+    min_val = np.min(surface[valid_mask])
+    working = np.where(valid_mask, surface, min_val)
+    window_size = initial_window
+    while window_size <= max_window:
+        window_radius = (window_size - 1) // 2
+        dh_threshold = min(initial_threshold + slope * window_radius, max_threshold)
+
+        struct = np.ones((window_size, window_size))
+        opened = grey_opening(working, footprint=struct)
+
+        diff = working - opened
+        non_ground_mask = diff > dh_threshold
+        working[non_ground_mask] = opened[non_ground_mask]
+
+        window_size = 2 * window_size - 1
+        if window_size > max_window:
+            break
+
+    return np.where(valid_mask, working, nodata)
+
+
+def refine_ground_surface(
+    ground: NDArray[np.floating],
+    nodata: float,
+    smoothen_radius: float,
+    elevation_threshold: float = REFINEMENT_ELEVATION_THRESHOLD,
+) -> NDArray[np.floating]:
+    """Refine the ground surface by removing points that deviate significantly."""
+    valid_mask = ground != nodata
+    if not np.any(valid_mask):
+        return ground.copy()
+    min_val = np.min(ground[valid_mask])
+    smooth_input = np.where(ground == nodata, min_val, ground)
+    smoothed = gaussian_filter(smooth_input, sigma=smoothen_radius)
+    diff = ground - smoothed
+    refined = ground.copy()
+    refined[(diff >= elevation_threshold) & valid_mask] = nodata
+    return refined
+
+
+def _process_coarse_dsm(
+    dsm: NDArray[np.floating],
+    cell_size: float,
+    nodata: float,
+    kernel_radius_meters: Optional[float],
+    slope: Optional[float],
+    initial_threshold: float,
+    max_threshold: float,
+) -> NDArray[np.floating]:
+    """Downsamples high-resolution DSM, processes at coarse resolution, and upsamples."""
+    target_res = MIN_PROCESSING_RESOLUTION_METERS
+
+    h, w = dsm.shape
+    scale = cell_size / target_res
+    new_h = int(h * scale)
+    new_w = int(w * scale)
+
+    if new_h < 10 or new_w < 10:
+        return _process_standard_dsm(
+            dsm, cell_size, nodata, kernel_radius_meters, slope, initial_threshold, max_threshold
+        )
+
+    print(
+        f"High resolution input ({cell_size:.4f}m). "
+        f"Downsampling to {MIN_PROCESSING_RESOLUTION_METERS}m for processing stability..."
+    )
+
+    valid_mask = dsm != nodata
+    invalid_mask = ~valid_mask
+    if not np.any(valid_mask):
+        return dsm.copy()
+
+    # Nearest neighbor fill before zooming to avoid interpolation artifacts with nodata
+    dsm_filled = dsm.copy()
+    if np.any(invalid_mask):
+        _, ind = distance_transform_edt(invalid_mask, return_distances=True, return_indices=True)
+        dsm_filled = dsm_filled[tuple(ind)]
+
+    dsm_coarse = zoom(dsm_filled, scale, order=1)
+
+    dtm_coarse = dsm_to_dtm(
+        dsm_coarse,
+        (target_res, target_res),
+        kernel_radius_meters=kernel_radius_meters,
+        slope=slope,
+        initial_threshold=initial_threshold,
+        max_threshold=max_threshold,
+        nodata=nodata,
+    )
+
+    # Upsample
+    dtm_fine = zoom(dtm_coarse, (h / new_h, w / new_w), order=1)
+    
+    # Restore original nodata mask
+    dtm_fine[invalid_mask] = nodata
+
+    return dtm_fine
+
+
+def _process_standard_dsm(
+    dsm: NDArray[np.floating],
+    cell_size: float,
+    nodata: float,
+    kernel_radius_meters: Optional[float],
+    slope: Optional[float],
+    initial_threshold: float,
+    max_threshold: float,
+) -> NDArray[np.floating]:
+    """Standard DTM generation pipeline."""
+    if slope is None:
+        slope = calculate_terrain_slope(dsm, cell_size, nodata)
+
+    max_dim = max(dsm.shape[0], dsm.shape[1])
+    params = get_adaptive_parameters(cell_size, max_image_dimension=max_dim, base_slope=slope)
+
+    if kernel_radius_meters is not None:
+        if cell_size < 0.01:
+            res_meters = cell_size * 111320.0
+        else:
+            res_meters = cell_size
+        res_meters = max(res_meters, 0.001)
+
+        max_window_px = int(kernel_radius_meters / res_meters) * 2 + 1
+        limit = max_dim
+        if limit % 2 == 0:
+            limit -= 1
+        max_window_px = min(max_window_px, limit)
+
+        params.pmf_max_window = max(max_window_px, params.pmf_initial_window)
+
+    ground = progressive_morphological_filter(
+        dsm,
+        nodata=nodata,
+        initial_window=params.pmf_initial_window,
+        max_window=params.pmf_max_window,
+        slope=params.pmf_slope,
+        initial_threshold=initial_threshold,
+        max_threshold=max_threshold,
+    )
+
+    ground = refine_ground_surface(
+        ground,
+        nodata=nodata,
+        smoothen_radius=params.refinement_smooth_sigma,
+        elevation_threshold=REFINEMENT_ELEVATION_THRESHOLD,
+    )
+
+    valid_mask = ground != nodata
+    if np.any(valid_mask):
+        min_val = np.min(ground[valid_mask])
+        smooth_input = np.where(ground == nodata, min_val, ground)
+        smoothed = gaussian_filter(smooth_input, sigma=params.final_smooth_sigma)
+        ground = np.where(valid_mask, smoothed, nodata)
+
+    # Gap interpolation
+    invalid_mask = ground == nodata
+    if np.any(invalid_mask) and np.any(valid_mask):
+        _, ind = distance_transform_edt(invalid_mask, return_distances=True, return_indices=True)
+        filled_ground = ground[tuple(ind)]
+        
+        if GAP_FILL_SMOOTHING_ITERATIONS > 0:
+            # Apply some smoothing specifically to the filled boundaries
+            smoothed_filled = gaussian_filter(filled_ground, sigma=1.0)
+            ground[invalid_mask] = smoothed_filled[invalid_mask]
+        else:
+            ground[invalid_mask] = filled_ground[invalid_mask]
+            
+    return ground
+
+
+def dsm_to_dtm(
+    dsm: NDArray[np.floating],
+    resolution: Tuple[float, float],
+    kernel_radius_meters: Optional[float] = None,
+    slope: Optional[float] = None,
+    initial_threshold: float = PMF_INITIAL_THRESHOLD,
+    max_threshold: float = PMF_MAX_THRESHOLD,
+    nodata: float = DEFAULT_NODATA,
+) -> NDArray[np.floating]:
+    """Generate DTM from DSM."""
+    cell_size = (abs(resolution[0]) + abs(resolution[1])) / 2.0
+    cell_size = max(cell_size, 0.001)
+
+    if cell_size < (MIN_PROCESSING_RESOLUTION_METERS * 0.9):
+        return _process_coarse_dsm(
+            dsm, cell_size, nodata, kernel_radius_meters, slope, initial_threshold, max_threshold
+        )
+
+    return _process_standard_dsm(dsm, cell_size, nodata, kernel_radius_meters, slope, initial_threshold, max_threshold)

--- a/qgis_plugin/dsm2dtm/ext_libs/dsm2dtm_core/algorithm.py
+++ b/qgis_plugin/dsm2dtm/ext_libs/dsm2dtm_core/algorithm.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, Tuple
 
 import numpy as np
-from scipy.ndimage import gaussian_filter, grey_opening, zoom, distance_transform_edt
+from scipy.ndimage import distance_transform_edt, gaussian_filter, grey_opening, zoom
 
 # Backward compatibility for numpy < 1.21 (QGIS uses 1.20)
 if TYPE_CHECKING:
@@ -222,7 +222,7 @@ def _process_coarse_dsm(
 
     # Upsample
     dtm_fine = zoom(dtm_coarse, (h / new_h, w / new_w), order=1)
-    
+
     # Restore original nodata mask
     dtm_fine[invalid_mask] = nodata
 
@@ -289,14 +289,14 @@ def _process_standard_dsm(
     if np.any(invalid_mask) and np.any(valid_mask):
         _, ind = distance_transform_edt(invalid_mask, return_distances=True, return_indices=True)
         filled_ground = ground[tuple(ind)]
-        
+
         if GAP_FILL_SMOOTHING_ITERATIONS > 0:
             # Apply some smoothing specifically to the filled boundaries
             smoothed_filled = gaussian_filter(filled_ground, sigma=1.0)
             ground[invalid_mask] = smoothed_filled[invalid_mask]
         else:
             ground[invalid_mask] = filled_ground[invalid_mask]
-            
+
     return ground
 
 

--- a/qgis_plugin/dsm2dtm/ext_libs/dsm2dtm_core/constants.py
+++ b/qgis_plugin/dsm2dtm/ext_libs/dsm2dtm_core/constants.py
@@ -1,0 +1,33 @@
+"""
+Constants for the DSM to DTM conversion pipeline.
+"""
+
+# No-data value
+DEFAULT_NODATA = -99999.0
+
+# Base parameters defined for 1.0 meter resolution
+BASE_RESOLUTION = 1.0
+
+# Progressive Morphological Filter (PMF) Parameters
+PMF_INITIAL_WINDOW_METERS = 3.0  # Start with 3m x 3m window
+PMF_MAX_WINDOW_METERS = 161.0  # Max window size ~161m
+PMF_SLOPE = 0.05  # Dimensionless (rise/run)
+PMF_INITIAL_THRESHOLD = 0.1  # Meters
+PMF_MAX_THRESHOLD = 20.0  # Meters - Relaxed for steep terrain
+
+# Smoothing Refinement Parameters
+REFINEMENT_SMOOTH_SIGMA_METERS = 5.0
+REFINEMENT_ELEVATION_THRESHOLD = 1.0
+FINAL_SMOOTH_SIGMA_METERS = 0.5
+
+# Processing Resolution
+# If input DSM resolution is finer than this (e.g. 0.05m), we downsample to this resolution
+# for the filtering steps to improve stability and performance, then upsample the result.
+MIN_PROCESSING_RESOLUTION_METERS = 0.5
+
+# Gap Filling Parameters
+GAP_FILL_MAX_SEARCH_DISTANCE_METERS = 100.0
+GAP_FILL_SMOOTHING_ITERATIONS = 0
+
+# Default Kernel Radius for CLI/Main (Meters)
+DEFAULT_KERNEL_RADIUS_METERS = 40.0

--- a/qgis_plugin/dsm2dtm/metadata.txt
+++ b/qgis_plugin/dsm2dtm/metadata.txt
@@ -2,7 +2,7 @@
 name=DSM to DTM
 qgisMinimumVersion=3.28
 description=Generate Digital Terrain Models (DTM) from Digital Surface Models (DSM). Removes buildings, vegetation, and cars.
-version=0.3.1
+version=0.3.2
 author=Naman Jain
 email=naman.jain@btech2015.iitgn.ac.in
 about=A robust, pure-Python implementation of Progressive Morphological Filtering for bare-earth extraction. No external dependencies required beyond what QGIS provides.

--- a/qgis_plugin/dsm2dtm/processing_algorithm.py
+++ b/qgis_plugin/dsm2dtm/processing_algorithm.py
@@ -196,7 +196,7 @@ class Dsm2DtmAlgorithm(QgsProcessingAlgorithm):
         out_band = out_ds.GetRasterBand(1)
         out_band.WriteArray(dtm)
         out_band.SetNoDataValue(float(nodata))
-        
+
         # Close dataset to flush to disk
         out_band.FlushCache()
         out_ds = None

--- a/qgis_plugin/dsm2dtm/processing_algorithm.py
+++ b/qgis_plugin/dsm2dtm/processing_algorithm.py
@@ -170,27 +170,36 @@ class Dsm2DtmAlgorithm(QgsProcessingAlgorithm):
         feedback.setProgress(80)
         feedback.pushInfo("Writing output raster...")
 
-        # Write output using rasterio (bundled with QGIS or vendored)
-        import rasterio
-        from rasterio.crs import CRS
-        from rasterio.transform import from_bounds
+        # Write output using GDAL (native to QGIS)
+        from osgeo import gdal, osr
 
-        transform = from_bounds(extent.xMinimum(), extent.yMinimum(), extent.xMaximum(), extent.yMaximum(), cols, rows)
+        driver = gdal.GetDriverByName("GTiff")
+        out_ds = driver.Create(output_path, cols, rows, 1, gdal.GDT_Float32)
+        if out_ds is None:
+            raise QgsProcessingException(f"Could not create output file: {output_path}")
 
-        profile = {
-            "driver": "GTiff",
-            "dtype": dtm.dtype,
-            "width": cols,
-            "height": rows,
-            "count": 1,
-            "crs": CRS.from_string(input_layer.crs().toWkt()),
-            "transform": transform,
-            "nodata": nodata,
-            "compress": "lzw",
-        }
+        # Set transform
+        xmin = extent.xMinimum()
+        ymax = extent.yMaximum()
+        pixel_width = extent.width() / cols
+        pixel_height = extent.height() / rows
+        # GDAL transform: [top_left_x, w_resolution, 0, top_left_y, 0, n_s_resolution (negative)]
+        out_transform = [xmin, pixel_width, 0.0, ymax, 0.0, -pixel_height]
+        out_ds.SetGeoTransform(out_transform)
 
-        with rasterio.open(output_path, "w", **profile) as dst:
-            dst.write(dtm, 1)
+        # Set projection
+        srs = osr.SpatialReference()
+        srs.ImportFromWkt(input_layer.crs().toWkt())
+        out_ds.SetProjection(srs.ExportToWkt())
+
+        # Write data
+        out_band = out_ds.GetRasterBand(1)
+        out_band.WriteArray(dtm)
+        out_band.SetNoDataValue(float(nodata))
+        
+        # Close dataset to flush to disk
+        out_band.FlushCache()
+        out_ds = None
 
         feedback.setProgress(100)
         feedback.pushInfo("Done!")

--- a/qgis_plugin/dsm2dtm/processing_algorithm.py
+++ b/qgis_plugin/dsm2dtm/processing_algorithm.py
@@ -1,6 +1,9 @@
 """DSM to DTM Processing Algorithm."""
 
 import numpy as np
+
+# Import vendored library (renamed to avoid conflict with plugin package)
+from dsm2dtm_core.algorithm import dsm_to_dtm
 from qgis.core import (
     QgsProcessingAlgorithm,
     QgsProcessingException,
@@ -104,9 +107,6 @@ class Dsm2DtmAlgorithm(QgsProcessingAlgorithm):
         Returns:
             Dictionary with output layer path.
         """
-        # Import vendored library (renamed to avoid conflict with plugin package)
-        from dsm2dtm_core.algorithm import dsm_to_dtm
-
         # Get parameters
         input_layer = self.parameterAsRasterLayer(parameters, self.INPUT, context)
         radius = self.parameterAsDouble(parameters, self.RADIUS, context)

--- a/qgis_plugin/scripts/build_plugin.py
+++ b/qgis_plugin/scripts/build_plugin.py
@@ -26,9 +26,6 @@ OUTPUT_ZIP = OUTPUT_DIR / "dsm2dtm_qgis_plugin.zip"
 
 def clean():
     """Remove previous build artifacts."""
-    if EXT_LIBS.exists():
-        shutil.rmtree(EXT_LIBS)
-        print(f"✓ Cleaned {EXT_LIBS}")
     if OUTPUT_ZIP.exists():
         OUTPUT_ZIP.unlink()
         print(f"✓ Removed old {OUTPUT_ZIP}")
@@ -101,7 +98,6 @@ def main():
         return 1
 
     clean()
-    vendor_library()
     create_zip()
 
     print()

--- a/tests/test_qgis_plugin.py
+++ b/tests/test_qgis_plugin.py
@@ -1,33 +1,34 @@
-import sys
 import os
+import sys
+
 import numpy as np
-import pytest
 
 # Add the qgis_plugin to sys.path to test its vendored version
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'qgis_plugin')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "qgis_plugin")))
+
 
 def test_qgis_algorithm_no_rasterio():
     """Verify that the plugin's algorithm can be imported and run without rasterio."""
     # Temporarily hide rasterio to simulate QGIS environment
     import sys
-    original_rasterio = sys.modules.pop('rasterio', None)
-    sys.modules['rasterio'] = None
-    
+
+    original_rasterio = sys.modules.pop("rasterio", None)
+    sys.modules["rasterio"] = None
+
     try:
         from dsm2dtm.ext_libs.dsm2dtm_core.algorithm import dsm_to_dtm
-        
+
         # Run a small test to ensure it works
         dsm = np.full((50, 50), 100.0, dtype=np.float32)
-        dsm[20:30, 20:30] = 120.0 # building
+        dsm[20:30, 20:30] = 120.0  # building
         resolution = (1.0, 1.0)
-        
+
         dtm = dsm_to_dtm(dsm, resolution, kernel_radius_meters=10.0, slope=0.1)
-        
+
         assert dtm[25, 25] < 110.0
         assert abs(dtm[0, 0] - 100.0) < 0.1
     finally:
         if original_rasterio is not None:
-            sys.modules['rasterio'] = original_rasterio
+            sys.modules["rasterio"] = original_rasterio
         else:
-            sys.modules.pop('rasterio', None)
-
+            sys.modules.pop("rasterio", None)

--- a/tests/test_qgis_plugin.py
+++ b/tests/test_qgis_plugin.py
@@ -3,8 +3,8 @@ import sys
 
 import numpy as np
 
-# Add the qgis_plugin to sys.path to test its vendored version
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "qgis_plugin")))
+# Add the ext_libs to sys.path to test the vendored version
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "qgis_plugin", "dsm2dtm", "ext_libs")))
 
 
 def test_qgis_algorithm_no_rasterio():
@@ -16,7 +16,7 @@ def test_qgis_algorithm_no_rasterio():
     sys.modules["rasterio"] = None
 
     try:
-        from dsm2dtm.ext_libs.dsm2dtm_core.algorithm import dsm_to_dtm
+        from dsm2dtm_core.algorithm import dsm_to_dtm
 
         # Run a small test to ensure it works
         dsm = np.full((50, 50), 100.0, dtype=np.float32)

--- a/tests/test_qgis_plugin.py
+++ b/tests/test_qgis_plugin.py
@@ -1,0 +1,33 @@
+import sys
+import os
+import numpy as np
+import pytest
+
+# Add the qgis_plugin to sys.path to test its vendored version
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'qgis_plugin')))
+
+def test_qgis_algorithm_no_rasterio():
+    """Verify that the plugin's algorithm can be imported and run without rasterio."""
+    # Temporarily hide rasterio to simulate QGIS environment
+    import sys
+    original_rasterio = sys.modules.pop('rasterio', None)
+    sys.modules['rasterio'] = None
+    
+    try:
+        from dsm2dtm.ext_libs.dsm2dtm_core.algorithm import dsm_to_dtm
+        
+        # Run a small test to ensure it works
+        dsm = np.full((50, 50), 100.0, dtype=np.float32)
+        dsm[20:30, 20:30] = 120.0 # building
+        resolution = (1.0, 1.0)
+        
+        dtm = dsm_to_dtm(dsm, resolution, kernel_radius_meters=10.0, slope=0.1)
+        
+        assert dtm[25, 25] < 110.0
+        assert abs(dtm[0, 0] - 100.0) < 0.1
+    finally:
+        if original_rasterio is not None:
+            sys.modules['rasterio'] = original_rasterio
+        else:
+            sys.modules.pop('rasterio', None)
+


### PR DESCRIPTION
This PR addresses #23 
### Changes
- **Detached Vendoring:** The QGIS plugin now uses a dedicated, manually maintained copy of the core algorithm
     (`ext_libs/dsm2dtm_core`) instead of dynamically importing the PyPI source.
    
- **Algorithm Rewrite:** Stripped `rasterio` out of the plugin's algorithmic logic, replacing `reproject` and `fillnodata` with
     native `scipy.ndimage` equivalents.

- Added tests to ensure the plugin's algorithm runs successfully even when `rasterio` is completely removed from the environment.

