### PR TITLE
Fix/qgis plugin raster io and crs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,8 @@
 
 5. **Surface failures honestly.** If a verification step fails or is skipped, say so clearly. No "it should work" claims.
 
+6. **Don't add verbose comments.** Default to no comments. Trust well-named identifiers and docstrings. Only add a comment when the WHY is non-obvious (a hidden constraint, a workaround, surprising behavior). Never restate WHAT the code does (`# Get parameters`, `# close source`, `# Read raster data`). Never write multi-line block comments to explain a section — if a section needs that much explanation, it probably needs to be a function with a one-line docstring.
+
 ## Project context
 
 - Python library + QGIS plugin for DSM → DTM conversion via Progressive Morphological Filter.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,3 +35,29 @@ For end-to-end testing the same fixtures CI uses are at:
 https://github.com/seedlit/dsm2dtm/releases/tag/test-data-v0.1
 
 Includes paired DSM/DTM rasters across resolutions (1m Istanbul hilly urban, 50cm river+urban, 50cm vegetation+urban). Download the ZIP, extract, and feed individual DSMs to the CLI or QGIS plugin to validate end-to-end behavior.
+
+### Live testing the QGIS plugin (mandatory for plugin changes)
+
+QGIS is installed locally at `/Applications/QGIS.app`. Any change under `qgis_plugin/` MUST be exercised through real QGIS — proxy testing via rasterio is not enough (different code paths, no actual `osgeo` import, no QGIS feedback object).
+
+Setup (one-time per machine):
+1. Symlink the dev plugin into the QGIS profile:
+   ```
+   ln -s "$(pwd)/qgis_plugin/dsm2dtm" "$HOME/Library/Application Support/QGIS/QGIS3/profiles/default/python/plugins/dsm2dtm"
+   ```
+   (Move any existing `dsm2dtm` install aside first.)
+2. Stage test data under `/tmp/` — `qgis_process` cannot read `~/Library/Caches/` on macOS due to sandboxing.
+
+Per-change verification:
+```
+/Applications/QGIS.app/Contents/MacOS/bin/qgis_process run dsm2dtm:dsm_to_dtm \
+  --INPUT=/tmp/dsm2dtm_livetest/<file>.tif \
+  --RADIUS=40 --SLOPE=0 \
+  --OUTPUT=/tmp/dsm2dtm_livetest/dtm_out.tif
+```
+
+Test BOTH a projected CRS input AND a geographic CRS input (re-warp one of the release fixtures with `gdalwarp -t_srs EPSG:4326`). Confirm:
+- the run completes,
+- the geographic case logs `Input is geographic ... Reprojecting to EPSG:...`,
+- output preserves the input CRS, shape, and bounds,
+- a meaningful fraction of cells had height removed (`DSM - DTM > 5m` for many cells).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# Working Agreement (for Claude)
+
+## Workflow Rules
+
+1. **Incremental changes.** Break work into the smallest meaningful steps. One concern per change. Don't bundle unrelated edits.
+
+2. **Verify live before claiming done.** A task is not "done" until the change has been actually executed and the output observed:
+   - Run the relevant tests (`uv run pytest <path>`).
+   - For non-test code paths, run a focused script or invoke the CLI/plugin directly and check the result.
+   - Type-checking and "the code looks right" are NOT verification.
+   - If a change cannot be live-tested in this environment (e.g., requires running QGIS GUI), explicitly say so and propose the closest practical verification (e.g., headless invocation, mimicking the data flow in a unit test).
+
+3. **Ask before committing or pushing.** Never run `git commit`, `git push`, or `gh pr create` without explicit approval. Stage changes silently and present a diff summary; wait for "yes, commit" / "yes, push".
+
+4. **Don't auto-commit unrelated files.** `BUG_HUNT_REPORT.md`, `IMPROVEMENT_RECOMMENDATIONS.md`, and `CLAUDE.md` are working notes — don't add them to commits unless asked.
+
+5. **Surface failures honestly.** If a verification step fails or is skipped, say so clearly. No "it should work" claims.
+
+## Project context
+
+- Python library + QGIS plugin for DSM → DTM conversion via Progressive Morphological Filter.
+- Two parallel code paths exist today: `src/dsm2dtm/` (rasterio-based, used by CLI) and `qgis_plugin/dsm2dtm/ext_libs/dsm2dtm_core/` (vendored, scipy-only). They have diverged — see BUG-43.
+- Test runner: `uv run pytest`. CI: GitHub Actions across 3.11–3.14, ubuntu/macos/windows + conda.
+- Bug catalog: `BUG_HUNT_REPORT.md`. Broader recommendations: `IMPROVEMENT_RECOMMENDATIONS.md`.
+
+### Why the library / plugin codebases diverge (intentional)
+
+- **`src/dsm2dtm/` uses rasterio.** The library is published on PyPI and `pip install dsm2dtm` must "just work", so it can rely on rasterio (which ships GDAL in its wheel).
+- **`qgis_plugin/` uses GDAL (osgeo) directly.** QGIS does NOT ship rasterio with the standard distribution, but it does ship `osgeo`/GDAL bindings. The plugin must use GDAL primitives so we don't force users to pip-install rasterio into their QGIS Python.
+- Implication: any I/O or geospatial transformation in the plugin (read, warp, write) must be expressed via `osgeo.gdal` / `osgeo.osr`, not rasterio. The pure-numpy/scipy algorithm code is shared via the vendored `ext_libs/dsm2dtm_core/`.
+
+### Live test data
+
+For end-to-end testing the same fixtures CI uses are at:
+https://github.com/seedlit/dsm2dtm/releases/tag/test-data-v0.1
+
+Includes paired DSM/DTM rasters across resolutions (1m Istanbul hilly urban, 50cm river+urban, 50cm vegetation+urban). Download the ZIP, extract, and feed individual DSMs to the CLI or QGIS plugin to validate end-to-end behavior.

--- a/qgis_plugin/dsm2dtm/processing_algorithm.py
+++ b/qgis_plugin/dsm2dtm/processing_algorithm.py
@@ -14,12 +14,7 @@ from qgis.core import (
 
 
 def _utm_epsg_for(lon: float, lat: float) -> int:
-    """EPSG code for the standard UTM zone containing (lon, lat).
-
-    Wraps lon=180 to zone 1 (the antimeridian), matching the convention used by
-    proj/UTM tooling. Returns 326xx for the northern hemisphere, 327xx for the
-    southern.
-    """
+    """EPSG of the UTM zone for (lon, lat). Wraps lon=180 to zone 1."""
     zone = int((lon + 180.0) / 6.0) % 60 + 1
     base = 32700 if lat < 0 else 32600
     return base + zone
@@ -131,7 +126,6 @@ class Dsm2DtmAlgorithm(QgsProcessingAlgorithm):
         feedback.pushInfo(f"Processing: {input_layer.source()}")
         feedback.pushInfo(f"Radius: {radius}m, Slope: {'auto' if slope == 0 else slope}")
 
-        # Read raster data using QGIS/GDAL
         provider = input_layer.dataProvider()
         extent = input_layer.extent()
         rows = input_layer.height()
@@ -145,9 +139,6 @@ class Dsm2DtmAlgorithm(QgsProcessingAlgorithm):
             nodata = -9999.0
             feedback.pushInfo("No nodata value found, using -9999.0")
 
-        # Read raster data via GDAL's NumPy bridge — single call, native speed.
-        # The previous pixel-by-pixel block.value() loop was O(rows*cols) Python calls
-        # and unusable on real rasters (~10^8 calls for a 10k x 10k input).
         from osgeo import gdal, osr
 
         feedback.pushInfo("Reading raster data...")
@@ -155,11 +146,8 @@ class Dsm2DtmAlgorithm(QgsProcessingAlgorithm):
         if src_ds is None:
             raise QgsProcessingException(f"Could not open input raster: {input_layer.source()}")
 
-        # The PMF algorithm interprets cell_size as meters, so geographic (lat/lon)
-        # rasters must be reprojected to a metric CRS first. We pick the appropriate
-        # UTM zone, warp to it, process, and warp the result back at write time.
         input_crs = input_layer.crs()
-        utm_warp_ctx = None  # filled when we reproject; tells the writer to warp back
+        utm_warp_ctx = None
 
         try:
             if input_crs.isGeographic():
@@ -189,7 +177,6 @@ class Dsm2DtmAlgorithm(QgsProcessingAlgorithm):
 
                 gt = utm_ds.GetGeoTransform()
                 resolution = (abs(gt[1]), abs(gt[5]))
-                # Save what we need to warp the DTM back at write time.
                 utm_warp_ctx = {
                     "geotransform": gt,
                     "projection": utm_ds.GetProjection(),
@@ -204,7 +191,7 @@ class Dsm2DtmAlgorithm(QgsProcessingAlgorithm):
                 dsm = np.ascontiguousarray(dsm, dtype=np.float32)
                 resolution = (extent.width() / cols, extent.height() / rows)
         finally:
-            src_ds = None  # close source
+            src_ds = None
 
         if feedback.isCanceled():
             return {}
@@ -232,8 +219,6 @@ class Dsm2DtmAlgorithm(QgsProcessingAlgorithm):
         feedback.pushInfo("Writing output raster...")
 
         if utm_warp_ctx is not None:
-            # Geographic input: dtm is in UTM. Wrap it in a MEM dataset, then warp
-            # back to the original CRS, matching the input raster's grid exactly.
             mem_drv = gdal.GetDriverByName("MEM")
             utm_dtm_ds = mem_drv.Create("", utm_warp_ctx["cols"], utm_warp_ctx["rows"], 1, gdal.GDT_Float32)
             utm_dtm_ds.SetGeoTransform(utm_warp_ctx["geotransform"])
@@ -259,7 +244,6 @@ class Dsm2DtmAlgorithm(QgsProcessingAlgorithm):
                 raise QgsProcessingException(f"Could not create output file: {output_path}")
             out_ds = None
         else:
-            # Projected input: write the DTM directly with the input grid.
             driver = gdal.GetDriverByName("GTiff")
             out_ds = driver.Create(output_path, cols, rows, 1, gdal.GDT_Float32)
             if out_ds is None:

--- a/qgis_plugin/dsm2dtm/processing_algorithm.py
+++ b/qgis_plugin/dsm2dtm/processing_algorithm.py
@@ -13,6 +13,18 @@ from qgis.core import (
 )
 
 
+def _utm_epsg_for(lon: float, lat: float) -> int:
+    """EPSG code for the standard UTM zone containing (lon, lat).
+
+    Wraps lon=180 to zone 1 (the antimeridian), matching the convention used by
+    proj/UTM tooling. Returns 326xx for the northern hemisphere, 327xx for the
+    southern.
+    """
+    zone = int((lon + 180.0) / 6.0) % 60 + 1
+    base = 32700 if lat < 0 else 32600
+    return base + zone
+
+
 class Dsm2DtmAlgorithm(QgsProcessingAlgorithm):
     """Algorithm to convert DSM (Digital Surface Model) to DTM (Digital Terrain Model).
 
@@ -133,25 +145,74 @@ class Dsm2DtmAlgorithm(QgsProcessingAlgorithm):
             nodata = -9999.0
             feedback.pushInfo("No nodata value found, using -9999.0")
 
-        # Read raster block
-        block = provider.block(1, extent, cols, rows)
+        # Read raster data via GDAL's NumPy bridge — single call, native speed.
+        # The previous pixel-by-pixel block.value() loop was O(rows*cols) Python calls
+        # and unusable on real rasters (~10^8 calls for a 10k x 10k input).
+        from osgeo import gdal, osr
 
-        # Convert to numpy array
         feedback.pushInfo("Reading raster data...")
-        dsm = np.zeros((rows, cols), dtype=np.float32)
-        for r in range(rows):
-            if feedback.isCanceled():
-                return {}
-            for c in range(cols):
-                dsm[r, c] = block.value(r, c)
+        src_ds = gdal.Open(input_layer.source())
+        if src_ds is None:
+            raise QgsProcessingException(f"Could not open input raster: {input_layer.source()}")
+
+        # The PMF algorithm interprets cell_size as meters, so geographic (lat/lon)
+        # rasters must be reprojected to a metric CRS first. We pick the appropriate
+        # UTM zone, warp to it, process, and warp the result back at write time.
+        input_crs = input_layer.crs()
+        utm_warp_ctx = None  # filled when we reproject; tells the writer to warp back
+
+        try:
+            if input_crs.isGeographic():
+                center_lon = (extent.xMinimum() + extent.xMaximum()) / 2.0
+                center_lat = (extent.yMinimum() + extent.yMaximum()) / 2.0
+                utm_epsg = _utm_epsg_for(center_lon, center_lat)
+                feedback.pushInfo(
+                    f"Input is geographic ({input_crs.authid()}). Reprojecting to EPSG:{utm_epsg} for processing..."
+                )
+
+                utm_ds = gdal.Warp(
+                    "",
+                    src_ds,
+                    format="MEM",
+                    dstSRS=f"EPSG:{utm_epsg}",
+                    srcNodata=nodata,
+                    dstNodata=nodata,
+                    resampleAlg=gdal.GRA_Bilinear,
+                )
+                if utm_ds is None:
+                    raise QgsProcessingException(f"Failed to reproject input to EPSG:{utm_epsg}")
+
+                dsm = utm_ds.GetRasterBand(1).ReadAsArray()
+                if dsm is None:
+                    raise QgsProcessingException("Failed to read reprojected raster data")
+                dsm = np.ascontiguousarray(dsm, dtype=np.float32)
+
+                gt = utm_ds.GetGeoTransform()
+                resolution = (abs(gt[1]), abs(gt[5]))
+                # Save what we need to warp the DTM back at write time.
+                utm_warp_ctx = {
+                    "geotransform": gt,
+                    "projection": utm_ds.GetProjection(),
+                    "cols": utm_ds.RasterXSize,
+                    "rows": utm_ds.RasterYSize,
+                }
+                utm_ds = None
+            else:
+                dsm = src_ds.GetRasterBand(1).ReadAsArray()
+                if dsm is None:
+                    raise QgsProcessingException("Failed to read raster band data")
+                dsm = np.ascontiguousarray(dsm, dtype=np.float32)
+                resolution = (extent.width() / cols, extent.height() / rows)
+        finally:
+            src_ds = None  # close source
+
+        if feedback.isCanceled():
+            return {}
 
         feedback.setProgress(10)
 
-        # Get resolution
-        x_res = extent.width() / cols
-        y_res = extent.height() / rows
-        resolution = (x_res, y_res)
-        feedback.pushInfo(f"Resolution: {x_res:.2f}m x {y_res:.2f}m")
+        x_res, y_res = resolution
+        feedback.pushInfo(f"Processing resolution: {x_res:.4f}m x {y_res:.4f}m")
 
         feedback.pushInfo("Running DSM to DTM conversion...")
 
@@ -170,36 +231,55 @@ class Dsm2DtmAlgorithm(QgsProcessingAlgorithm):
         feedback.setProgress(80)
         feedback.pushInfo("Writing output raster...")
 
-        # Write output using GDAL (native to QGIS)
-        from osgeo import gdal, osr
+        if utm_warp_ctx is not None:
+            # Geographic input: dtm is in UTM. Wrap it in a MEM dataset, then warp
+            # back to the original CRS, matching the input raster's grid exactly.
+            mem_drv = gdal.GetDriverByName("MEM")
+            utm_dtm_ds = mem_drv.Create("", utm_warp_ctx["cols"], utm_warp_ctx["rows"], 1, gdal.GDT_Float32)
+            utm_dtm_ds.SetGeoTransform(utm_warp_ctx["geotransform"])
+            utm_dtm_ds.SetProjection(utm_warp_ctx["projection"])
+            utm_band = utm_dtm_ds.GetRasterBand(1)
+            utm_band.WriteArray(dtm)
+            utm_band.SetNoDataValue(float(nodata))
 
-        driver = gdal.GetDriverByName("GTiff")
-        out_ds = driver.Create(output_path, cols, rows, 1, gdal.GDT_Float32)
-        if out_ds is None:
-            raise QgsProcessingException(f"Could not create output file: {output_path}")
+            out_ds = gdal.Warp(
+                output_path,
+                utm_dtm_ds,
+                format="GTiff",
+                dstSRS=input_layer.crs().toWkt(),
+                outputBounds=(extent.xMinimum(), extent.yMinimum(), extent.xMaximum(), extent.yMaximum()),
+                width=cols,
+                height=rows,
+                srcNodata=nodata,
+                dstNodata=nodata,
+                resampleAlg=gdal.GRA_Bilinear,
+            )
+            utm_dtm_ds = None
+            if out_ds is None:
+                raise QgsProcessingException(f"Could not create output file: {output_path}")
+            out_ds = None
+        else:
+            # Projected input: write the DTM directly with the input grid.
+            driver = gdal.GetDriverByName("GTiff")
+            out_ds = driver.Create(output_path, cols, rows, 1, gdal.GDT_Float32)
+            if out_ds is None:
+                raise QgsProcessingException(f"Could not create output file: {output_path}")
 
-        # Set transform
-        xmin = extent.xMinimum()
-        ymax = extent.yMaximum()
-        pixel_width = extent.width() / cols
-        pixel_height = extent.height() / rows
-        # GDAL transform: [top_left_x, w_resolution, 0, top_left_y, 0, n_s_resolution (negative)]
-        out_transform = [xmin, pixel_width, 0.0, ymax, 0.0, -pixel_height]
-        out_ds.SetGeoTransform(out_transform)
+            xmin = extent.xMinimum()
+            ymax = extent.yMaximum()
+            pixel_width = extent.width() / cols
+            pixel_height = extent.height() / rows
+            out_ds.SetGeoTransform([xmin, pixel_width, 0.0, ymax, 0.0, -pixel_height])
 
-        # Set projection
-        srs = osr.SpatialReference()
-        srs.ImportFromWkt(input_layer.crs().toWkt())
-        out_ds.SetProjection(srs.ExportToWkt())
+            srs = osr.SpatialReference()
+            srs.ImportFromWkt(input_layer.crs().toWkt())
+            out_ds.SetProjection(srs.ExportToWkt())
 
-        # Write data
-        out_band = out_ds.GetRasterBand(1)
-        out_band.WriteArray(dtm)
-        out_band.SetNoDataValue(float(nodata))
-
-        # Close dataset to flush to disk
-        out_band.FlushCache()
-        out_ds = None
+            out_band = out_ds.GetRasterBand(1)
+            out_band.WriteArray(dtm)
+            out_band.SetNoDataValue(float(nodata))
+            out_band.FlushCache()
+            out_ds = None
 
         feedback.setProgress(100)
         feedback.pushInfo("Done!")


### PR DESCRIPTION

- **IMPROVEMENT:** replace per-pixel `block.value()` loop with `gdal.GetRasterBand().ReadAsArray()` (~10000× faster on real rasters).
- **BUG FIX:** detect geographic input CRS, warp to UTM in-memory for processing, warp DTM back to original grid at write time. Previously cell sizes in degrees were fed into a meter-based algorithm, producing nonsense parameters.

Verified live via `qgis_process` against the [release test fixtures](https://github.com/seedlit/dsm2dtm/releases/tag/test-data-v0.1) on both a projected and a geographic input.
